### PR TITLE
Turning instructor list into a list

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,13 +4,13 @@ root: .
 venue: IUPUI
 address: ICTC, 535 W Michigan, Indianapolis, IN 46202
 country: United-States
-humandate: Mar 03-06 , 2015  
+humandate: Mar 03-06, 2015  
 humantime: 8:30 am - 4:30 pm 
 startdate: 2015-03-03   
-enddate:   2015-03-06 
+enddate: 2015-03-06 
 latlng: 39.773931,-86.167524
 registration: restricted
-instructor: ["Mats Rynge, Emelie Harstad, Bala Desinghu, David Champion, Suchandra Thapa, Rob Quick"]
+instructor: ["Mats Rynge", "Emelie Harstad", "Bala Desinghu", "David Champion", "Suchandra Thapa", "Rob Quick"]
 helper: ["Chris Pipes, Elizabeth Prout"]
 contact: balamurugan@uchicago.edu 
 ---


### PR DESCRIPTION
This PR turns the list of instructor names into a list of strings rather than a list containing one long string.
